### PR TITLE
Update ssl-params.conf

### DIFF
--- a/nginx/snippets/ssl-params.conf
+++ b/nginx/snippets/ssl-params.conf
@@ -1,7 +1,7 @@
 # from https://cipherli.st/
 # and https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
 
-ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+ssl_protocols TLSv1.2 TLSv1.3;
 ssl_prefer_server_ciphers on;
 ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
 ssl_ecdh_curve secp384r1;
@@ -9,7 +9,7 @@ ssl_session_cache shared:SSL:10m;
 ssl_session_tickets off;
 ssl_stapling on;
 ssl_stapling_verify on;
-resolver 8.8.8.8 8.8.4.4 valid=300s;
+resolver 9.9.9.9 149.112.112.112 valid=300s;
 resolver_timeout 5s;
 # Disable preloading HSTS for now.  You can use the commented out header line that includes
 # the "preload" directive if you understand the implications.


### PR DESCRIPTION
Hi Dmitrius7! Thank you so much for your work. This made it really easy and simple to set up UrBackup with HTTPS! I had some unsolicited suggestions, which are included into this .conf file. I am not sure if this is everyone's experience but when I setup HTTPS, my browser defaulted to TLSv1, which is now deprecated along with TLSv1.1 (https://www.ietf.org/rfc/rfc8996.html). I changed the .conf file to just TLSv1.2 and TLSv1.3. Another suggestion I had was to change the DNS resolver from google (8.8.8.8) to quad9 (9.9.9.9). I think most people set up self hosted services like UrBackup in order to control and secure their own data and privacy. Having the DNS resolver as 8.8.8.8 (google's DNS) might be considered as going against most of that and inadvertently cause a "leak." If you don't prefer quad9, there are also a list of privacy preserving DNS providers listed here (e.g. Mullvad): https://www.privacyguides.org/dns/#recommended-providers